### PR TITLE
Adjusted Syntax

### DIFF
--- a/src/imtui-impl-ncurses.cpp
+++ b/src/imtui-impl-ncurses.cpp
@@ -39,7 +39,8 @@ namespace {
             wtimeout(stdscr, 0);
             while (tNow_us < tNextCur_us - 100) {
                 if (tNow_us + 0.5*tStepActive_us < tNextCur_us) {
-                    if (int ch = wgetch(stdscr); ch != ERR) {
+		    int ch = wgetch(stdscr);
+                    if (ch != ERR) {
                         ungetch(ch);
                         tNextCur_us = tNow_us;
                         wtimeout(stdscr, 1);


### PR DESCRIPTION
I adjusted this syntax because I was running a build on my project that I'm using ImTui in. On my Travis CI builds the compiler did not like 

```c++
if (int ch = wgetch(stdscr); ch != ERR) {
```

So I changed it to 
```c++
int ch = wgetch(stdscr);
if (ch != ERR) {
```

Below are links to my builds, I'm going to look into what why it didn't seem to like that syntax since it worked fine on my local machines. This isn't a huge change, but maybe it will save a few minutes for someone down the road assuming you want to merge it in and it doesn't clash with your style too much.

Project: https://github.com/clbx/Cosmic
Failing Build: https://travis-ci.org/clbx/Cosmic/builds/653635685
Passing Build (Ignore Windows): https://travis-ci.org/clbx/Cosmic/builds/653882093 