### PR TITLE
FindCurses: Detect and satisfy dependency on tinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,16 @@ endif()
 
 if (IMTUI_SUPPORT_NCURSES)
     find_package(Curses REQUIRED)
+    CHECK_LIBRARY_EXISTS("${CURSES_NCURSES_LIBRARY}"
+                         nodelay "" CURSES_NCURSES_HAS_NODELAY)
+    if(NOT CURSES_NCURSES_HAS_NODELAY)
+            find_library(CURSES_EXTRA_LIBRARY tinfo)
+            CHECK_LIBRARY_EXISTS("${CURSES_EXTRA_LIBRARY}"
+                                    nodelay "" CURSES_TINFO_HAS_NODELAY)
+    endif()
+    if(CURSES_EXTRA_LIBRARY)
+            set(CURSES_LIBRARIES ${CURSES_LIBRARIES} ${CURSES_EXTRA_LIBRARY})
+    endif()
 endif()
 
 # main


### PR DESCRIPTION
'nodelay' symbol will be missing if tinfo is seperate from ncurses
since FindCurses only checks for 'cbreak' symbol to determine that.
this fixes that for now.

upstream merge request:
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4892