### PR TITLE
Fix HN Example App -Wsign-compare

### DIFF
--- a/examples/hnterm/impl-ncurses.cpp
+++ b/examples/hnterm/impl-ncurses.cpp
@@ -190,7 +190,7 @@ void updateRequests_impl() {
     curl_multi_perform(g_cm, &still_alive);
 
     while (still_alive < MAX_PARALLEL && g_fetchQueue.size() > 0) {
-        int idx = 0;
+        long unsigned int idx = 0;
         while (g_fetchData[idx].running) {
             ++idx;
             if (idx == g_fetchData.size()) break;


### PR DESCRIPTION
Hey there! Thanks for the great library!

I received the following small compiler warning when attempting to `make` on Rocky Linux with the following gcc version:

```bash
/home/jcalabro/go/src/github.com/ggerganov/imtui/examples/hnterm/impl-ncurses.cpp: In function ‘void updateRequests_impl()’:
/home/jcalabro/go/src/github.com/ggerganov/imtui/examples/hnterm/impl-ncurses.cpp:196:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::array<Data, 5>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  196 |             if (idx == g_fetchData.size()) break;
      |                 ~~~~^~~~~~~~~~~~~~~~~~~~~
/home/jcalabro/go/src/github.com/ggerganov/imtui/examples/hnterm/impl-ncurses.cpp:198:17: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::array<Data, 5>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  198 |         if (idx == g_fetchData.size()) break;
      |             ~~~~^~~~~~~~~~~~~~~~~~~~~
[100%] Linking CXX executable ../../bin/hnterm
[100%] Built target hnterm
```

```bash
$ c++ --version
c++ (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Which should be fixed by this PR, which just bumps the `idx` variable from an `int` => `long unsigned int` to match signedness and width.

Thanks!